### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/589/212/1/1125892121.geojson
+++ b/data/112/589/212/1/1125892121.geojson
@@ -31,6 +31,9 @@
     "name:arg_x_preferred":[
         "Chiconi"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u064a\u0643\u0646\u0649"
+    ],
     "name:ast_x_preferred":[
         "Chiconi"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:ces_x_preferred":[
         "Chiconi"
+    ],
+    "name:che_x_preferred":[
+        "\u0428\u0438\u043a\u043e\u043d\u0438"
     ],
     "name:cos_x_preferred":[
         "Chiconi"
@@ -160,6 +166,9 @@
     "name:lit_x_preferred":[
         "Chiconi"
     ],
+    "name:lld_x_preferred":[
+        "Chiconi"
+    ],
     "name:ltz_x_preferred":[
         "Chiconi"
     ],
@@ -220,6 +229,9 @@
     "name:ron_x_preferred":[
         "Chiconi"
     ],
+    "name:rus_x_preferred":[
+        "\u0428\u0438\u043a\u043e\u043d\u0438"
+    ],
     "name:scn_x_preferred":[
         "Chiconi"
     ],
@@ -271,6 +283,9 @@
     "name:wol_x_preferred":[
         "Chiconi"
     ],
+    "name:zho_x_preferred":[
+        "\u5e0c\u79d1\u5c3c"
+    ],
     "name:zul_x_preferred":[
         "Chiconi"
     ],
@@ -313,7 +328,7 @@
         }
     ],
     "wof:id":1125892121,
-    "wof:lastmodified":1566662633,
+    "wof:lastmodified":1690927551,
     "wof:name":"Chiconi",
     "wof:parent_id":85671203,
     "wof:placetype":"locality",

--- a/data/112/589/213/3/1125892133.geojson
+++ b/data/112/589/213/3/1125892133.geojson
@@ -31,6 +31,9 @@
     "name:arg_x_preferred":[
         "Bou\u00e9ni"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u064a\u0646\u0649"
+    ],
     "name:ast_x_preferred":[
         "Bou\u00e9ni"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:ces_x_preferred":[
         "Bou\u00e9ni"
+    ],
+    "name:che_x_preferred":[
+        "\u0411\u0443\u0435\u043d\u0438"
     ],
     "name:cos_x_preferred":[
         "Bou\u00e9ni"
@@ -157,6 +163,9 @@
     "name:lit_x_preferred":[
         "Bou\u00e9ni"
     ],
+    "name:lld_x_preferred":[
+        "Bou\u00e9ni"
+    ],
     "name:ltz_x_preferred":[
         "Bou\u00e9ni"
     ],
@@ -217,6 +226,9 @@
     "name:ron_x_preferred":[
         "Bou\u00e9ni"
     ],
+    "name:rus_x_preferred":[
+        "\u0411\u0443\u044d\u043d\u0438"
+    ],
     "name:scn_x_preferred":[
         "Bou\u00e9ni"
     ],
@@ -268,6 +280,9 @@
     "name:wol_x_preferred":[
         "Bou\u00e9ni"
     ],
+    "name:zho_x_preferred":[
+        "\u5e03\u57c3\u5c3c"
+    ],
     "name:zul_x_preferred":[
         "Bou\u00e9ni"
     ],
@@ -310,7 +325,7 @@
         }
     ],
     "wof:id":1125892133,
-    "wof:lastmodified":1566662633,
+    "wof:lastmodified":1690927551,
     "wof:name":"Bou\u00e9ni",
     "wof:parent_id":85671203,
     "wof:placetype":"locality",

--- a/data/112/601/964/7/1126019647.geojson
+++ b/data/112/601/964/7/1126019647.geojson
@@ -31,6 +31,9 @@
     "name:arg_x_preferred":[
         "Mamoudzou"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0645\u0648\u062f\u0632\u0648"
+    ],
     "name:ast_x_preferred":[
         "Mamoudzou"
     ],
@@ -48,6 +51,12 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u043c\u0443\u0434\u0437\u0443"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0430\u043c\u0443\u0434\u0437\u0443"
+    ],
+    "name:ben_x_preferred":[
+        "\u09ae\u09be\u09ae\u09c1\u09a6\u099c\u09c1"
     ],
     "name:bos_x_preferred":[
         "Mamoudzou"
@@ -69,6 +78,9 @@
     ],
     "name:che_x_preferred":[
         "\u041c\u0430\u043c\u0443\u0434\u0437\u0443"
+    ],
+    "name:chv_x_preferred":[
+        "\u041c\u0430\u043c\u0443\u0446\u0443"
     ],
     "name:ckb_x_preferred":[
         "\u0645\u0627\u0645\u06c6\u062f\u0632\u06c6"
@@ -208,6 +220,9 @@
     "name:kat_x_preferred":[
         "\u10db\u10d0\u10db\u10e3\u10ea\u10e3"
     ],
+    "name:kaz_x_preferred":[
+        "\u041c\u0430\u043c\u0443\u0446\u0443"
+    ],
     "name:kon_x_preferred":[
         "Mamoudzou"
     ],
@@ -229,6 +244,9 @@
     "name:lit_x_preferred":[
         "Mamudzu"
     ],
+    "name:lld_x_preferred":[
+        "Mamoudzou"
+    ],
     "name:ltz_x_preferred":[
         "Mamoudzou"
     ],
@@ -246,6 +264,9 @@
     ],
     "name:msa_x_preferred":[
         "Mamoudzou"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0645\u0627\u0645\u0648\u062f\u0632\u0648"
     ],
     "name:nan_x_preferred":[
         "Mamoudzou"
@@ -273,6 +294,9 @@
     ],
     "name:oci_x_preferred":[
         "Mamodzo"
+    ],
+    "name:oss_x_preferred":[
+        "\u041c\u0430\u043c\u0443\u0446\u0443"
     ],
     "name:pap_x_preferred":[
         "Mamoudzou"
@@ -310,6 +334,9 @@
     "name:rus_x_preferred":[
         "\u041c\u0430\u043c\u0443\u0434\u0437\u0443"
     ],
+    "name:rus_x_variant":[
+        "\u041c\u0430\u043c\u0443\u0446\u0443"
+    ],
     "name:scn_x_preferred":[
         "Mamoudzou"
     ],
@@ -326,6 +353,9 @@
         "Mamawdsaw"
     ],
     "name:spa_x_preferred":[
+        "Mamoudzou"
+    ],
+    "name:sqi_x_preferred":[
         "Mamoudzou"
     ],
     "name:srd_x_preferred":[
@@ -449,7 +479,7 @@
         }
     ],
     "wof:id":1126019647,
-    "wof:lastmodified":1607390893,
+    "wof:lastmodified":1690927552,
     "wof:name":"Mamoudzou",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/838/9/1141908389.geojson
+++ b/data/114/190/838/9/1141908389.geojson
@@ -27,6 +27,9 @@
     "name:arg_x_preferred":[
         "Dzaoudzi"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0632\u0627\u0648\u062f\u0632\u0649"
+    ],
     "name:ast_x_preferred":[
         "Dzaoudzi"
     ],
@@ -45,8 +48,14 @@
     "name:cat_x_preferred":[
         "Dzaoudzi"
     ],
+    "name:ceb_x_preferred":[
+        "Dzaoudzi"
+    ],
     "name:ces_x_preferred":[
         "Dzaoudzi"
+    ],
+    "name:che_x_preferred":[
+        "\u0414\u0437\u0430\u0443\u0434\u0437\u0438"
     ],
     "name:cos_x_preferred":[
         "Dzaoudzi"
@@ -59,6 +68,9 @@
     ],
     "name:deu_x_preferred":[
         "Dzaoudzi"
+    ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03b6\u03b1\u03bf\u03c5\u03bd\u03c4\u03b6\u03af"
     ],
     "name:eng_x_preferred":[
         "Dzaoudzi"
@@ -147,6 +159,9 @@
     "name:kal_x_preferred":[
         "Dzaoudzi"
     ],
+    "name:kaz_x_preferred":[
+        "\u0414\u0437\u0430\u0443\u0434\u0437\u0438"
+    ],
     "name:kon_x_preferred":[
         "Dzaoudzi"
     ],
@@ -166,6 +181,9 @@
         "Dzaoudzi"
     ],
     "name:lit_x_preferred":[
+        "Dzaoudzi"
+    ],
+    "name:lld_x_preferred":[
         "Dzaoudzi"
     ],
     "name:ltz_x_preferred":[
@@ -419,7 +437,7 @@
         }
     ],
     "wof:id":1141908389,
-    "wof:lastmodified":1636501493,
+    "wof:lastmodified":1690927552,
     "wof:name":"Dzaoudzi",
     "wof:parent_id":85671203,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.